### PR TITLE
SWE-agent[bot] PR to fix: Error message says "field" when it should say "label"

### DIFF
--- a/compiler-core/src/error.rs
+++ b/compiler-core/src/error.rs
@@ -1378,7 +1378,7 @@ Names in a Gleam module must be unique so one will need to be renamed."
 
                 TypeError::DuplicateField { location, label } => {
                     let text =
-                        format!("The field `{label}` has already been defined. Rename this field.");
+                        format!("The label `{label}` has already been defined. Rename this label.");
                     Diagnostic {
                         title: "Duplicate field".into(),
                         text,


### PR DESCRIPTION
This is a PR opened by AI tool [SWE Agent](https://github.com/princeton-nlp/SWE-agent/) to close [#1](https://github.com/codemankey87/gleam/issues/1) (Error message says "field" when it should say "label").

Closes #1.

<details>
<summary>Thought process ('trajectory') of SWE-agent (click to expand)</summary>

**Action (0)**:
```
search_dir "The field `a` has already been defined"
```
**👀 Observation (0)**:
```
/bin/bash: line 216: a: command not found
No matches found for "The field  has already been defined" in /codemankey87__gleam
```
**️🧑‍🚒 Response (0)**:
First, we should try to locate the file that contains the error message we need to fix. Since the issue mentions a specific error message related to duplicate labels, we can search the repository for the string "The field `a` has already been defined" to find where this message is generated.

Let's start by searching the current directory for the error message string.

```
search_dir "The field `a` has already been defined"
```
**🧠 State (0)**:
```
{"open_file": "n/a", "working_dir": "/codemankey87__gleam"}
```
**💡 Thought (0)**:
First, we should try to locate the file that contains the error message we need to fix. Since the issue mentions a specific error message related to duplicate labels, we can search the repository for the string "The field `a` has already been defined" to find where this message is generated.

Let's start by searching the current directory for the error message string.

---

**Action (1)**:
```
search_dir "has already been defined"
```
**👀 Observation (1)**:
```
Found 1 matches for "has already been defined" in /codemankey87__gleam:
/codemankey87__gleam/compiler-core/src/error.rs (1 matches)
End of matches for "has already been defined" in /codemankey87__gleam
```
**️🧑‍🚒 Response (1)**:
It seems that the search did not yield any results, possibly because the specific string "The field `a` has already been defined" includes a variable part (`a`). Let's try a more general search term that is likely to be part of the error message, such as "has already been defined". This should help us find the source file where the error message is generated.

```
search_dir "has already been defined"
```
**🧠 State (1)**:
```
{"open_file": "n/a", "working_dir": "/codemankey87__gleam"}
```
**💡 Thought (1)**:
It seems that the search did not yield any results, possibly because the specific string "The field `a` has already been defined" includes a variable part (`a`). Let's try a more general search term that is likely to be part of the error message, such as "has already been defined". This should help us find the source file where the error message is generated.

---

**Action (2)**:
```
open compiler-core/src/error.rs
```
**👀 Observation (2)**:
```
[File: /codemankey87__gleam/compiler-core/src/error.rs (3462 lines total)]
1:#![allow(clippy::unwrap_used, clippy::expect_used)]
2:use crate::build::{Runtime, Target};
3:use crate::diagnostic::{Diagnostic, Label, Location};
4:use crate::type_::error::RecordVariants;
5:use crate::type_::error::{MissingAnnotation, UnknownTypeHint};
6:use crate::type_::{error::PatternMatchKind, FieldAccessUsage};
7:use crate::{ast::BinOp, parse::error::ParseErrorType, type_::Type};
8:use crate::{
9:    bit_array,
10:    diagnostic::Level,
11:    javascript,
12:    type_::{pretty::Printer, UnifyErrorSituation},
13:};
14:use ecow::EcoString;
15:use hexpm::version::ResolutionError;
16:use itertools::Itertools;
17:use pubgrub::package::Package;
18:use pubgrub::report::DerivationTree;
19:use pubgrub::version::Version;
20:use std::collections::HashSet;
21:use std::env;
22:use std::fmt::Debug;
23:use std::io::Write;
24:use std::path::PathBuf;
25:use termcolor::Buffer;
26:use thiserror::Error;
27:use vec1::Vec1;
28:
29:use camino::{Utf8Path, Utf8PathBuf};
30:
31:pub type Name = EcoString;
32:
33:pub type Result<Ok, Err = Error> = std::result::Result<Ok, Err>;
34:
35:macro_rules! wrap_format {
36:    ($($tts:tt)*) => {
37:        wrap(&format!($($tts)*))
38:    }
39:}
40:
41:#[derive(Debug, Clone, Eq, PartialEq)]
42:pub struct UnknownImportDetails {
43:    pub module: Name,
44:    pub location: crate::ast::SrcSpan,
45:    pub path: Utf8PathBuf,
46:    pub src: EcoString,
47:    pub modules: Vec<EcoString>,
48:}
49:
50:#[derive(Debug, Eq, PartialEq, Error, Clone)]
51:pub enum Error {
52:    #[error("failed to parse Gleam source code")]
53:    Parse {
54:        path: Utf8PathBuf,
55:        src: EcoString,
56:        error: crate::parse::error::ParseError,
57:    },
58:
59:    #[error("type checking failed")]
60:    Type {
61:        path: Utf8PathBuf,
62:        src: EcoString,
63:        errors: Vec1<crate::type_::Error>,
64:    },
65:
66:    #[error("unknown import {import}")]
67:    UnknownImport {
68:        import: EcoString,
69:        // Boxed to prevent this variant from being overly large
70:        details: Box<UnknownImportDetails>,
71:    },
72:
73:    #[error("duplicate module {module}")]
74:    DuplicateModule {
75:        module: Name,
76:        first: Utf8PathBuf,
77:        second: Utf8PathBuf,
78:    },
79:
80:    #[error("duplicate source file {file}")]
81:    DuplicateSourceFile { file: String },
82:
83:    #[error("cyclical module imports")]
84:    ImportCycle { modules: Vec<EcoString> },
85:
86:    #[error("cyclical package dependencies")]
87:    PackageCycle { packages: Vec<EcoString> },
88:
89:    #[error("file operation failed")]
90:    FileIo {
91:        kind: FileKind,
92:        action: FileIoAction,
93:        path: Utf8PathBuf,
94:        err: Option<String>,
95:    },
96:
97:    #[error("Non Utf-8 Path: {path}")]
98:    NonUtf8Path { path: PathBuf },
99:
100:    #[error("{error}")]
(3362 more lines below)
```
**️🧑‍🚒 Response (2)**:
We have found a match in the file `compiler-core/src/error.rs`. Let's open this file to locate the exact line where the error message is generated and make the necessary correction.

```
open compiler-core/src/error.rs
```
**🧠 State (2)**:
```
{"open_file": "n/a", "working_dir": "/codemankey87__gleam"}
```
**💡 Thought (2)**:
We have found a match in the file `compiler-core/src/error.rs`. Let's open this file to locate the exact line where the error message is generated and make the necessary correction.

---

**Action (3)**:
```
search_file "has already been defined"
```
**👀 Observation (3)**:
```
Found 1 matches for "has already been defined" in /codemankey87__gleam/compiler-core/src/error.rs:
Line 1381:                        format!("The field `{label}` has already been defined. Rename this field.");
End of matches for "has already been defined" in /codemankey87__gleam/compiler-core/src/error.rs
```
**️🧑‍🚒 Response (3)**:
The file `error.rs` is quite large, with 3462 lines in total. Since we don't know the exact line number where the error message is defined, we'll need to search within this file for the string "has already been defined" to find the relevant section.

```
search_file "has already been defined"
```
**🧠 State (3)**:
```
{"open_file": "/codemankey87__gleam/compiler-core/src/error.rs", "working_dir": "/codemankey87__gleam"}
```
**💡 Thought (3)**:
The file `error.rs` is quite large, with 3462 lines in total. Since we don't know the exact line number where the error message is defined, we'll need to search within this file for the string "has already been defined" to find the relevant section.

---

**Action (4)**:
```
goto 1381
```
**👀 Observation (4)**:
```
[File: /codemankey87__gleam/compiler-core/src/error.rs (3462 lines total)]
(1365 more lines above)
1366:                                text: Some("Redefined here".into()),
1367:                                span: *location,
1368:                            },
1369:                            path: path.clone(),
1370:                            src: src.clone(),
1371:                            extra_labels: vec![Label {
1372:                                text: Some("First defined here".into()),
1373:                                span: *previous_location,
1374:                            }],
1375:                        }),
1376:                    }
1377:                }
1378:
1379:                TypeError::DuplicateField { location, label } => {
1380:                    let text =
1381:                        format!("The field `{label}` has already been defined. Rename this field.");
1382:                    Diagnostic {
1383:                        title: "Duplicate field".into(),
1384:                        text,
1385:                        hint: None,
1386:                        level: Level::Error,
1387:                        location: Some(Location {
1388:                            label: Label {
1389:                                text: None,
1390:                                span: *location,
1391:                            },
1392:                            path: path.clone(),
1393:                            src: src.clone(),
1394:                            extra_labels: vec![],
1395:                        }),
1396:                    }
1397:                }
1398:
1399:                TypeError::DuplicateArgument { location, label } => {
1400:                    let text = format!("The labelled argument `{label}` has already been supplied.");
1401:                    Diagnostic {
1402:                        title: "Duplicate argument".into(),
1403:                        text,
1404:                        hint: None,
1405:                        level: Level::Error,
1406:                        location: Some(Location {
1407:                            label: Label {
1408:                                text: None,
1409:                                span: *location,
1410:                            },
1411:                            path: path.clone(),
1412:                            src: src.clone(),
1413:                            extra_labels: vec![],
1414:                        }),
1415:                    }
1416:                }
1417:
1418:                TypeError::RecursiveType { location } => {
1419:                    let text = "I don't know how to work out what type this value has. It seems
1420:to be defined in terms of itself.
1421:
1422:Hint: Add some type annotations and try again."
1423:                        .into();
1424:                    Diagnostic {
1425:                        title: "Recursive type".into(),
1426:                        text,
1427:                        hint: None,
1428:                        level: Level::Error,
1429:                        location: Some(Location {
1430:                            label: Label {
1431:                                text: None,
1432:                                span: *location,
1433:                            },
1434:                            path: path.clone(),
1435:                            src: src.clone(),
1436:                            extra_labels: vec![],
1437:                        }),
1438:                    }
1439:                }
1440:
1441:                TypeError::NotFn { location, typ } => {
1442:                    let mut printer = Printer::new();
1443:                    let text = format!(
1444:                        "This value is being called as a function but its type is:\n\n{}",
1445:                        printer.pretty_print(typ, 4)
1446:                    );
1447:                    Diagnostic {
1448:                        title: "Type mismatch".into(),
1449:                        text,
1450:                        hint: None,
1451:                        level: Level::Error,
1452:                        location: Some(Location {
1453:                            label: Label {
1454:                                text: None,
1455:                                span: *location,
1456:                            },
1457:                            path: path.clone(),
1458:                            src: src.clone(),
1459:                            extra_labels: vec![],
1460:                        }),
1461:                    }
1462:                }
1463:
1464:                TypeError::UnknownRecordField {
1465:                    usage,
(1997 more lines below)
```
**️🧑‍🚒 Response (4)**:
We have found the line in the `error.rs` file where the incorrect error message is generated. It's on line 1381. Let's navigate to that line and edit the message to correctly use the word "label" instead of "field".

```
goto 1381
```
**🧠 State (4)**:
```
{"open_file": "/codemankey87__gleam/compiler-core/src/error.rs", "working_dir": "/codemankey87__gleam"}
```
**💡 Thought (4)**:
We have found the line in the `error.rs` file where the incorrect error message is generated. It's on line 1381. Let's navigate to that line and edit the message to correctly use the word "label" instead of "field".

---

**Action (5)**:
```
edit 1381:1381
                        format!("The label `{label}` has already been defined. Rename this label.");
end_of_edit
```
**👀 Observation (5)**:
```
[File: /codemankey87__gleam/compiler-core/src/error.rs (3462 lines total)]
(1330 more lines above)
1331:                        text,
1332:                        hint: None,
1333:                        level: Level::Error,
1334:                        location: Some(Location {
1335:                            label: Label {
1336:                                text: Some("Redefined here".into()),
1337:                                span: *second_location,
1338:                            },
1339:                            path: path.clone(),
1340:                            src: src.clone(),
1341:                            extra_labels: vec![Label {
1342:                                text: Some("First defined here".into()),
1343:                                span: *first_location,
1344:                            }],
1345:                        }),
1346:                    }
1347:                }
1348:
1349:                TypeError::DuplicateTypeName {
1350:                    name,
1351:                    location,
1352:                    previous_location,
1353:                    ..
1354:                } => {
1355:                    let text = format!(
1356:                        "The type `{name}` has been defined multiple times.
1357:Names in a Gleam module must be unique so one will need to be renamed."
1358:                    );
1359:                    Diagnostic {
1360:                        title: "Duplicate type definition".into(),
1361:                        text,
1362:                        hint: None,
1363:                        level: Level::Error,
1364:                        location: Some(Location {
1365:                            label: Label {
1366:                                text: Some("Redefined here".into()),
1367:                                span: *location,
1368:                            },
1369:                            path: path.clone(),
1370:                            src: src.clone(),
1371:                            extra_labels: vec![Label {
1372:                                text: Some("First defined here".into()),
1373:                                span: *previous_location,
1374:                            }],
1375:                        }),
1376:                    }
1377:                }
1378:
1379:                TypeError::DuplicateField { location, label } => {
1380:                    let text =
1381:                        format!("The label `{label}` has already been defined. Rename this label.");
1382:                    Diagnostic {
1383:                        title: "Duplicate field".into(),
1384:                        text,
1385:                        hint: None,
1386:                        level: Level::Error,
1387:                        location: Some(Location {
1388:                            label: Label {
1389:                                text: None,
1390:                                span: *location,
1391:                            },
1392:                            path: path.clone(),
1393:                            src: src.clone(),
1394:                            extra_labels: vec![],
1395:                        }),
1396:                    }
1397:                }
1398:
1399:                TypeError::DuplicateArgument { location, label } => {
1400:                    let text = format!("The labelled argument `{label}` has already been supplied.");
1401:                    Diagnostic {
1402:                        title: "Duplicate argument".into(),
1403:                        text,
1404:                        hint: None,
1405:                        level: Level::Error,
1406:                        location: Some(Location {
1407:                            label: Label {
1408:                                text: None,
1409:                                span: *location,
1410:                            },
1411:                            path: path.clone(),
1412:                            src: src.clone(),
1413:                            extra_labels: vec![],
1414:                        }),
1415:                    }
1416:                }
1417:
1418:                TypeError::RecursiveType { location } => {
1419:                    let text = "I don't know how to work out what type this value has. It seems
1420:to be defined in terms of itself.
1421:
1422:Hint: Add some type annotations and try again."
1423:                        .into();
1424:                    Diagnostic {
1425:                        title: "Recursive type".into(),
1426:                        text,
1427:                        hint: None,
1428:                        level: Level::Error,
1429:                        location: Some(Location {
1430:                            label: Label {
(2032 more lines below)
File updated. Please review the changes and make sure they are correct (correct indentation, no duplicate lines, etc). Edit the file again if necessary.
```
**️🧑‍🚒 Response (5)**:
We are now at the correct location in the `error.rs` file. Let's edit line 1381 to change the word "field" to "label" in the error message.

```
edit 1381:1381
                        format!("The label `{label}` has already been defined. Rename this label.");
end_of_edit
```
**🧠 State (5)**:
```
{"open_file": "/codemankey87__gleam/compiler-core/src/error.rs", "working_dir": "/codemankey87__gleam"}
```
**💡 Thought (5)**:
We are now at the correct location in the `error.rs` file. Let's edit line 1381 to change the word "field" to "label" in the error message.

---

**Action (6)**:
```
submit
```
**👀 Observation (6)**:
```
diff --git a/compiler-core/src/error.rs b/compiler-core/src/error.rs
index 410fa366..febd037c 100644
--- a/compiler-core/src/error.rs
+++ b/compiler-core/src/error.rs
@@ -1378,7 +1378,7 @@ Names in a Gleam module must be unique so one will need to be renamed."
 
                 TypeError::DuplicateField { location, label } => {
                     let text =
-                        format!("The field `{label}` has already been defined. Rename this field.");
+                        format!("The label `{label}` has already been defined. Rename this label.");
                     Diagnostic {
                         title: "Duplicate field".into(),
                         text,
```
**️🧑‍🚒 Response (6)**:
The error message has been successfully updated to use the word "label" instead of "field". The changes appear to be correct, with proper indentation and no duplicate lines.

Now that the necessary change has been made, we should submit our changes to the code base. Let's use the `submit` command to do so.

```
submit
```
**🧠 State (6)**:
```
{"open_file": "/codemankey87__gleam/compiler-core/src/error.rs", "working_dir": "/codemankey87__gleam"}
```
**💡 Thought (6)**:
The error message has been successfully updated to use the word "label" instead of "field". The changes appear to be correct, with proper indentation and no duplicate lines.

Now that the necessary change has been made, we should submit our changes to the code base. Let's use the `submit` command to do so.
</details>